### PR TITLE
Fix YouTube options passing

### DIFF
--- a/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
+++ b/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
@@ -59,7 +59,7 @@
 			$vid = $this->videoId($input);
 			switch($this->videoHost($input)) {
 				case VIMEO:
-					return "//player.vimeo.com/video/$vid";
+					return "//player.vimeo.com/video/$vid?";
 				break;
 				
 				case YOUTUBE:
@@ -97,7 +97,7 @@
 						unset($options['height']);
 					}
 					
-					$url .= '?' . http_build_query($options);
+					$url .= '&' . http_build_query($options);
 				}
 				
 				$originalPath = craft()->path->getTemplatesPath();


### PR DESCRIPTION
You could not pass options to YouTube and have them work. The string was getting multiple ? due to the YouTube URL having a ?controls=2 in it already - thus breaking all passed options.

Fixed.
